### PR TITLE
[Fix] TIC Visualization from raw data caused exception

### DIFF
--- a/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICVisualizerWindow.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICVisualizerWindow.java
@@ -138,6 +138,7 @@ public class TICVisualizerWindow extends Stage {
     // setBackground(Color.white);
 
     ticPlot = new TICPlot();
+    ticPlot.setPlotType(plotType);
     mainPane.setCenter(ticPlot);
 
     toolBar = new ToolBar();


### PR DESCRIPTION
Hi Tomas,

previously selecting TIC/XIC in the TICVisualizerWindow caused a crash, because the plotType was not set accordingly in the ticPlot. The crash occured when the raw data files were added.

`Caused by: java.lang.IllegalArgumentException: Added dataset of class 'class io.github.mzmine.modules.visualization.chromatogram.TICDataSet' does not have a compatible plotType. Expected 'Base peak intensity'
	at io.github.mzmine.modules.visualization.chromatogram.TICPlot.addTICDataset(TICPlot.java:590)
	at io.github.mzmine.modules.visualization.chromatogram.TICVisualizerWindow.addRawDataFile(TICVisualizerWindow.java:410)
	at io.github.mzmine.modules.visualization.chromatogram.TICVisualizerWindow.<init>(TICVisualizerWindow.java:211)
	at io.github.mzmine.modules.visualization.chromatogram.ChromatogramVisualizerModule.runModule(ChromatogramVisualizerModule.java:83)
	at io.github.mzmine.main.MZmineCore.runMZmineModule(MZmineCore.java:261)
	at io.github.mzmine.gui.mainwindow.MainWindowController.handleShowChromatogram(MainWindowController.java:281)
	... 54 more`

Best regards
Steffen