### PR TITLE
Legend fix

### DIFF
--- a/src/main/java/io/github/mzmine/gui/chartbasics/chartthemes/EStandardChartTheme.java
+++ b/src/main/java/io/github/mzmine/gui/chartbasics/chartthemes/EStandardChartTheme.java
@@ -24,9 +24,12 @@ import java.awt.Paint;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.StandardChartTheme;
 import org.jfree.chart.axis.NumberAxis;
+import org.jfree.chart.plot.XYPlot;
 import org.jfree.chart.renderer.category.StandardBarPainter;
 import org.jfree.chart.renderer.xy.StandardXYBarPainter;
+import org.jfree.chart.title.LegendTitle;
 import org.jfree.chart.title.PaintScaleLegend;
+import org.jfree.chart.ui.RectangleEdge;
 import io.github.mzmine.gui.chartbasics.chartthemes.ChartThemeFactory.THEME;
 
 /**
@@ -103,7 +106,6 @@ public class EStandardChartTheme extends StandardChartTheme {
 
   @Override
   public void apply(JFreeChart chart) {
-    // TODO Auto-generated method stub
     super.apply(chart);
     //
     chart.getXYPlot().setDomainGridlinesVisible(showXGrid);
@@ -142,6 +144,8 @@ public class EStandardChartTheme extends StandardChartTheme {
     chart.setAntiAlias(isAntiAliased());
     chart.getTitle().setVisible(isShowTitle());
     chart.getPlot().setBackgroundAlpha(isNoBackground() ? 0 : 1);
+    
+    fixLegend(chart);
   }
 
   public boolean isNoBackground() {
@@ -158,6 +162,25 @@ public class EStandardChartTheme extends StandardChartTheme {
         new Color(cchart.getRed(), cchart.getGreen(), cchart.getBlue(), state ? 0 : 255));
   }
 
+  /**
+   * Fixes the legend item's colour after the colours of the datasets/series in the plot were
+   * changed.
+   * 
+   * @param chart The chart.
+   */
+  public static void fixLegend(JFreeChart chart) {
+    XYPlot plot = chart.getXYPlot();
+    LegendTitle oldLegend = chart.getLegend();
+    RectangleEdge pos = oldLegend.getPosition();
+    chart.removeLegend();
+    
+    LegendTitle newLegend = new LegendTitle(plot);
+    newLegend.setPosition(pos);
+    newLegend.setItemFont(oldLegend.getItemFont());
+    chart.addLegend(newLegend);
+    newLegend.setVisible(oldLegend.isVisible());
+  }
+  
   // GETTERS AND SETTERS
   public Paint getAxisLinePaint() {
     return axisLinePaint;


### PR DESCRIPTION
Fix for legends not having the same color as the plot.

I thought it would make sense to make the method static. Maybe move it to a util class at some point, when the colour scheme is being established throughout mzmine.